### PR TITLE
Feature#9 - AccessToken 갱신 API 연결 및 유저 기능 처리 플로우 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,14 @@ import { theme } from "@styles/theme";
 import GlobalStyle from "@styles/globalStyle";
 import { router } from "@routes/index";
 import ModalRoot from "./components/common/Modal";
+import GlobalLoading from "./components/common/GlobalLoading";
+
 export default function App() {
   return (
     <ThemeProvider theme={theme}>
       <RouterProvider router={router} />
       <GlobalStyle />
+      <GlobalLoading />
       <ModalRoot />
     </ThemeProvider>
   );

--- a/src/api/bookmark/hooks/useBookmark.ts
+++ b/src/api/bookmark/hooks/useBookmark.ts
@@ -1,12 +1,13 @@
 import { useMutation } from "@tanstack/react-query";
 import { getBookmarkList } from "../bookmark";
 import { useBookmarkStore } from "@/stores/bookmark";
+import { withDelayedGlobalLoading } from "@/utils/delayedGlobalLoading";
 
 export const useBookmark = () => {
   const setBookmarkList = useBookmarkStore((state) => state.setBookmarks);
 
   const { mutate, isPending, isError } = useMutation({
-    mutationFn: getBookmarkList,
+    mutationFn: () => withDelayedGlobalLoading(getBookmarkList()),
     onSuccess: (data) => {
       setBookmarkList(data);
     },

--- a/src/api/news/hooks/useNewsList.ts
+++ b/src/api/news/hooks/useNewsList.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getNewsList } from "../news";
 import { useNewsListStore } from "@/stores/newsList";
 import type { NewsListItemType } from "@/types/newsList";
+import { withDelayedGlobalLoading } from "@/utils/delayedGlobalLoading";
 
 export const useNewsList = () => {
   const setNewsList = useNewsListStore((state) => state.setNewsList);
@@ -9,7 +10,7 @@ export const useNewsList = () => {
   return useQuery<NewsListItemType[], Error>({
     queryKey: ["newsList"],
     queryFn: async () => {
-      const data = await getNewsList();
+      const data = await withDelayedGlobalLoading(getNewsList());
       setNewsList(data);
       return data;
     },

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -111,9 +111,15 @@ export const applyInterceptors = (instance: AxiosInstance): void => {
         try {
           const refreshToken = useUserStore.getState().refreshToken;
 
-          const res = await axios.post("/api/user/refresh", {
-            refreshToken,
-          });
+          const res = await axios.post(
+            "/api/user/refresh",
+            {},
+            {
+              headers: {
+                Authorization: `Bearer ${refreshToken}`,
+              },
+            }
+          );
 
           const newAccessToken = res.data.result.accessToken;
           useUserStore.getState().setAccessToken(newAccessToken);

--- a/src/api/user/hooks/useLevel.ts
+++ b/src/api/user/hooks/useLevel.ts
@@ -2,12 +2,14 @@ import { useMutation } from "@tanstack/react-query";
 import { postSelectLevel } from "../level";
 import { useUserStore } from "@/stores/user";
 import { LevelType } from "@/types/level";
+import { withDelayedGlobalLoading } from "@/utils/delayedGlobalLoading";
 
 export const useLevel = () => {
   const setLevel = useUserStore((state) => state.setLevel);
 
   return useMutation({
-    mutationFn: (level: LevelType) => postSelectLevel(level),
+    mutationFn: (level: LevelType) =>
+      withDelayedGlobalLoading(postSelectLevel(level)),
     onSuccess: (_, level) => {
       setLevel(level);
     },

--- a/src/api/user/hooks/useMyProfile.ts
+++ b/src/api/user/hooks/useMyProfile.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchMyProfile } from "../user";
 import { useUserStore } from "@/stores/user";
 import type { ProfileResult } from "../user";
+import { withDelayedGlobalLoading } from "@/utils/delayedGlobalLoading";
 
 export const useMyProfile = () => {
   const setProfile = useUserStore((state) => state.setProfile);
@@ -9,7 +10,7 @@ export const useMyProfile = () => {
   return useQuery<ProfileResult>({
     queryKey: ["myProfile"],
     queryFn: async () => {
-      const data = await fetchMyProfile();
+      const data = await withDelayedGlobalLoading(fetchMyProfile());
       setProfile({
         ...data,
         joinDate:

--- a/src/api/words/hooks/useWords.ts
+++ b/src/api/words/hooks/useWords.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { getMyWords, postAddWord, deleteWord } from "../words";
 import { useWordsStore } from "@/stores/words";
+import { withDelayedGlobalLoading } from "@/utils/delayedGlobalLoading";
 
 export const useMyWords = () => {
   const setWords = useWordsStore((state) => state.setWords);
@@ -8,7 +9,8 @@ export const useMyWords = () => {
   return useQuery({
     queryKey: ["myWords"],
     queryFn: async () => {
-      const { words, totalCount } = await getMyWords();
+      const { words, totalCount } =
+        await withDelayedGlobalLoading(getMyWords());
       setWords(words, totalCount);
       return words;
     },
@@ -20,7 +22,8 @@ export const useAddWord = () => {
   const addWord = useWordsStore((state) => state.addWord);
 
   return useMutation({
-    mutationFn: (wordId: number) => postAddWord(wordId),
+    mutationFn: (wordId: number) =>
+      withDelayedGlobalLoading(postAddWord(wordId)),
     onSuccess: (newWord) => {
       addWord(newWord);
     },
@@ -32,7 +35,7 @@ export const useDeleteWord = () => {
 
   return useMutation({
     mutationFn: async (savedWordId: number) => {
-      const res = await deleteWord(savedWordId);
+      const res = await withDelayedGlobalLoading(deleteWord(savedWordId));
       return res.deletedSavedWordId;
     },
     onSuccess: (deletedWordId) => {

--- a/src/api/words/words.ts
+++ b/src/api/words/words.ts
@@ -12,81 +12,39 @@ interface DeleteWordResult {
 }
 
 export const getMyWords = async (): Promise<WordsResult> => {
-  try {
-    const response = await sendRequest<WordsResult>(wordsInstance, "GET", "");
+  const response = await sendRequest<WordsResult>(wordsInstance, "GET", "");
 
-    if (!response.success) {
-      throw new Error(response.message || "단어장 불러오기 실패");
-    }
-
-    return response.result;
-  } catch (error: any) {
-    const status = error?.response?.status;
-
-    if (status === 401 || status === 403) {
-      // 토큰이 유효하지 않거나 로그인이 안되어 있을 시 로그인 페이지로 강제 이동
-      if (typeof window !== "undefined") {
-        window.location.replace("/login");
-      }
-      throw new Error(`${status} Redirected to login`);
-    }
-
-    throw new Error("단어장 요청 실패");
+  if (!response.success) {
+    throw new Error(response.message || "단어장 불러오기 실패");
   }
+
+  return response.result;
 };
 
 export const postAddWord = async (wordId: number) => {
-  try {
-    const response = await sendRequest<WordType>(
-      wordsInstance,
-      "POST",
-      `/${wordId}`
-    );
+  const response = await sendRequest<WordType>(
+    wordsInstance,
+    "POST",
+    `/${wordId}`
+  );
 
-    if (!response.success) {
-      throw new Error(response.message || "단어장 저장 실패");
-    }
-
-    return response.result;
-  } catch (error: any) {
-    const status = error?.response?.status;
-
-    if (status === 401 || status === 403) {
-      // 토큰이 유효하지 않거나 로그인이 안되어 있을 시 로그인 페이지로 강제 이동
-      if (typeof window !== "undefined") {
-        window.location.replace("/login");
-      }
-      throw new Error(`${status} Redirected to login`);
-    }
-
-    throw new Error("단어 추가 실패");
+  if (!response.success) {
+    throw new Error(response.message || "단어장 저장 실패");
   }
+
+  return response.result;
 };
 
 export const deleteWord = async (savedWordId: number) => {
-  try {
-    const response = await sendRequest<DeleteWordResult>(
-      wordsInstance,
-      "DELETE",
-      `/${savedWordId}`
-    );
+  const response = await sendRequest<DeleteWordResult>(
+    wordsInstance,
+    "DELETE",
+    `/${savedWordId}`
+  );
 
-    if (!response.success) {
-      throw new Error(response.message || "단어장 저장 실패");
-    }
-
-    return response.result;
-  } catch (error: any) {
-    const status = error?.response?.status;
-
-    if (status === 401 || status === 403) {
-      // 토큰이 유효하지 않거나 로그인이 안되어 있을 시 로그인 페이지로 강제 이동
-      if (typeof window !== "undefined") {
-        window.location.replace("/login");
-      }
-      throw new Error(`${status} Redirected to login`);
-    }
-
-    throw new Error("단어 삭제 실패");
+  if (!response.success) {
+    throw new Error(response.message || "단어장 저장 실패");
   }
+
+  return response.result;
 };

--- a/src/components/common/GlobalLoading/index.tsx
+++ b/src/components/common/GlobalLoading/index.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useGlobalLoading } from "@/hooks/common/useGlobalLoading";
+import { useModal } from "@/hooks/common/useModal";
+
+const GlobalLoading = () => {
+  const { isGlobalLoading } = useGlobalLoading();
+  const { openModal, closeModal } = useModal();
+
+  useEffect(() => {
+    if (isGlobalLoading) {
+      openModal("loading", {
+        message: "잠시만 기다려주세요...",
+      });
+    } else {
+      closeModal();
+    }
+  }, [isGlobalLoading]);
+
+  return null;
+};
+
+export default GlobalLoading;

--- a/src/components/common/Modal/ConfirmModal/index.tsx
+++ b/src/components/common/Modal/ConfirmModal/index.tsx
@@ -5,6 +5,8 @@ interface ConfirmModalProps {
   message?: string;
   onConfirm: () => void;
   onClose: () => void;
+  confirmText?: string;
+  cancelText?: string;
 }
 
 const ConfirmModal = ({
@@ -12,14 +14,16 @@ const ConfirmModal = ({
   message,
   onConfirm,
   onClose,
+  confirmText = "확인",
+  cancelText = "취소",
 }: ConfirmModalProps) => {
   return (
     <>
       <S.ModalTitle>{title}</S.ModalTitle>
       <S.ModalText>{message}</S.ModalText>
       <S.ModalButtonGroup>
-        <CommonButton title="취소" variant="disabled" onClick={onClose} />
-        <CommonButton title="확인" variant="blue" onClick={onConfirm} />
+        <CommonButton title={cancelText} variant="disabled" onClick={onClose} />
+        <CommonButton title={confirmText} variant="blue" onClick={onConfirm} />
       </S.ModalButtonGroup>
     </>
   );

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -18,6 +18,8 @@ const ModalRoot = () => {
             message={props.message}
             onConfirm={props.onConfirm}
             onClose={props.onClose}
+            confirmText={props.confirmText}
+            cancelText={props.cancelText}
           />
         );
       case "check":

--- a/src/components/common/ProtectedRoute/index.tsx
+++ b/src/components/common/ProtectedRoute/index.tsx
@@ -1,0 +1,34 @@
+import { Outlet, useNavigate } from "react-router-dom";
+import { useUserStore } from "@/stores/user";
+import { useEffect, useState } from "react";
+import { useModal } from "@/hooks/common/useModal";
+
+export const ProtectedRoute = () => {
+  const { accessToken } = useUserStore();
+  const { openModal, closeModal } = useModal();
+  const navigate = useNavigate();
+  const [modalShown, setModalShown] = useState(false);
+
+  useEffect(() => {
+    if (!accessToken && !modalShown) {
+      setModalShown(true);
+      openModal("confirm", {
+        title: "로그인이 필요한 서비스입니다.",
+        message: "로그인 하시겠습니까?",
+        confirmText: "로그인",
+        cancelText: "돌아가기",
+        onConfirm: () => {
+          closeModal();
+          navigate("/login");
+        },
+        onClose: () => {
+          closeModal();
+          navigate("/", { replace: true });
+        },
+      });
+    }
+  }, [accessToken, modalShown, openModal, closeModal, navigate]);
+  if (accessToken) return <Outlet />;
+
+  return null;
+};

--- a/src/components/common/TopBar/index.tsx
+++ b/src/components/common/TopBar/index.tsx
@@ -12,8 +12,13 @@ const TopBar = ({ title }: TopBarProps) => {
   const navigate = useNavigate();
 
   const handleBack = () => {
-    navigate(-1);
+    if (location.pathname === "/login") {
+      navigate("/", { replace: true });
+    } else {
+      navigate(-1);
+    }
   };
+
   return (
     <S.Container>
       <S.ArrowContainer onClick={handleBack}>

--- a/src/hooks/common/useGlobalLoading.ts
+++ b/src/hooks/common/useGlobalLoading.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+interface GlobalLoadingState {
+  loadingCount: number;
+  isGlobalLoading: boolean;
+  startGlobalLoading: () => void;
+  stopGlobalLoading: () => void;
+}
+
+export const useGlobalLoading = create<GlobalLoadingState>((set) => ({
+  loadingCount: 0,
+  isGlobalLoading: false,
+  startGlobalLoading: () =>
+    set((state) => ({
+      loadingCount: state.loadingCount + 1,
+      isGlobalLoading: true,
+    })),
+  stopGlobalLoading: () =>
+    set((state) => {
+      const newCount = state.loadingCount - 1;
+      return {
+        loadingCount: newCount,
+        isGlobalLoading: newCount > 0,
+      };
+    }),
+}));

--- a/src/pages/mypage/components/MyProfile/index.tsx
+++ b/src/pages/mypage/components/MyProfile/index.tsx
@@ -6,13 +6,11 @@ import { formatDateToDot } from "@/utils/format";
 import { useMyProfile } from "@/api/user/hooks/useMyProfile";
 
 export const MyProfile = () => {
-  const { isLoading } = useMyProfile();
+  useMyProfile();
   const name = useUserStore((state) => state.name);
   const profileImage = useUserStore((state) => state.profileImage);
   const joinDate = useUserStore((state) => state.joinDate);
   const savedWordCount = useUserStore((state) => state.savedWordCount);
-
-  if (isLoading) return <div>불러오는 중...</div>;
 
   return (
     <S.ProfileCard>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,6 +11,7 @@ import {
   Bookmark,
   Setting,
 } from "@pages/index";
+import { ProtectedRoute } from "@/components/common/ProtectedRoute";
 
 export const router = createBrowserRouter([
   {
@@ -18,13 +19,49 @@ export const router = createBrowserRouter([
     element: <Layout />,
     children: [
       { index: true, element: <Home /> },
-      { path: "words", element: <Words /> },
-      { path: "mypage", element: <Mypage /> },
+      {
+        path: "words",
+        element: <ProtectedRoute />,
+        children: [
+          {
+            path: "",
+            element: <Words />,
+          },
+        ],
+      },
+      {
+        path: "mypage",
+        element: <ProtectedRoute />,
+        children: [
+          {
+            path: "",
+            element: <Mypage />,
+          },
+        ],
+      },
       { path: "news", element: <News /> },
       { path: "news/:newsId", element: <NewsDetail /> },
-      { path: "bookmark", element: <Bookmark /> },
+      {
+        path: "bookmark",
+        element: <ProtectedRoute />,
+        children: [
+          {
+            path: "",
+            element: <Bookmark />,
+          },
+        ],
+      },
       { path: "login", element: <Login /> },
-      { path: "setting", element: <Setting /> },
+      {
+        path: "setting",
+        element: <ProtectedRoute />,
+        children: [
+          {
+            path: "",
+            element: <Setting />,
+          },
+        ],
+      },
       { path: "login/oauth2/code/kakao", element: <KakaoLogin /> },
     ],
   },

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -28,6 +28,7 @@ interface UserState {
     joinDate: Date;
     savedWordCount: number;
   }) => void;
+  setAccessToken: (accessToken: string) => void;
   setLevel: (level: LevelType) => void;
 }
 
@@ -71,6 +72,7 @@ export const useUserStore = create<UserState>()(
         });
         useBookmarkStore.getState().reset();
       },
+      setAccessToken: (accessToken: string) => set({ accessToken }),
       setLevel: (level: LevelType) => set({ level }),
       setProfile: ({ name, profileImage, level, joinDate, savedWordCount }) =>
         set({

--- a/src/utils/delayedGlobalLoading.ts
+++ b/src/utils/delayedGlobalLoading.ts
@@ -1,0 +1,22 @@
+import { useGlobalLoading } from "@/hooks/common/useGlobalLoading";
+
+export const withDelayedGlobalLoading = async <T>(
+  promise: Promise<T>,
+  delay = 300 // ms 기준, 300ms 이후에만 로딩 표시
+): Promise<T> => {
+  const { startGlobalLoading, stopGlobalLoading } = useGlobalLoading.getState();
+
+  let timeoutId: NodeJS.Timeout | null = null;
+
+  timeoutId = setTimeout(() => {
+    startGlobalLoading();
+  }, delay);
+
+  try {
+    const result = await promise;
+    return result;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    stopGlobalLoading();
+  }
+};


### PR DESCRIPTION
## 관련 이슈
해결한 문제를 지정하는 Issue Index에 연결해야 합니다.

- Resolves : #9 
 
## 작업 사항
해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다.

- interceptors의 response 부분에 401 error 발생 시 현재 저장된 accessToken 대신 refreshToken을 header에 넣어서 accessToken을 갱신하고 해당 토큰으로 재요청이 가게끔 코드를 수정하였습니다.
- 로그인이 필요한 페이지(setting, words, mypage 등)에 로그인 하지 않은 상태로 접근 시 모달을 띄워 로그인페이지로 이동할 수 있도록 합니다.
    - 해당 로직을 공통 컴포넌트로 제작 후 필요한 페이지마다 ProtectedRoute 컴포넌트를 감싸 재활용합니다.
- GlobalLoadingState를 만들고 useGlobalLoading 훅을 만들어 전역으로 로딩 상태를 관리하도록 하였으며, 딜레이를 넣는 util 함수를 추가하여 요청 시간에 따라 긴 요청의 경우에만 로딩 모달이 뜨도록 하였습니다.

## 참고 사항
없습니다.
